### PR TITLE
remove only tls1.1

### DIFF
--- a/modules/loom/main.tf
+++ b/modules/loom/main.tf
@@ -46,7 +46,7 @@ module "cloudfront" {
         http_port              = 80
         https_port             = 443
         origin_protocol_policy = "match-viewer"
-        origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+        origin_ssl_protocols   = ["TLSv1", "TLSv1.2"]
       }
 
       custom_header = [


### PR DESCRIPTION
I first experimented with the version of CloudFront's terraform module in PR #42, then changed it to try taking away the TLS v1.1 option in the origin resource.

This PR looks to see what is different in the state of the GitHub Actions state when I change only the TLS 1.1.

I'm curious about both how Overmind itself handles the "state" of the system, as well as understanding how GitHub Actions affects the results of Overmind.  I would expect that there isn't shared state between each build on GitHub Actions, and this would help me validate that assumption.