### PR TITLE
Pin terraform-aws-modules/ecs/aws to a working version

### DIFF
--- a/modules/scenarios/loom.tf
+++ b/modules/scenarios/loom.tf
@@ -398,7 +398,8 @@ resource "aws_cloudfront_response_headers_policy" "headers-policy" {
 #
 
 module "ecs" {
-  source = "terraform-aws-modules/ecs/aws"
+  source  = "terraform-aws-modules/ecs/aws"
+  version = "5.12.1"
 
   cluster_name = "example-${var.example_env}"
 


### PR DESCRIPTION
With the AWS ecosystem currently going through the transition to 6.0, we want to stay on 5 until this blows over.