### PR TITLE
feat: Demonstrate cost signals integration with infrastructure changes

### DIFF
--- a/.github/workflows/automatic.yml
+++ b/.github/workflows/automatic.yml
@@ -133,3 +133,31 @@ jobs:
         if: (success() || failure() || cancelled()) && github.event.pull_request.merged == true
         with:
           ovm-api-key: ${{ secrets.OVM_API_KEY }}
+
+  cost-analysis:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Terraform Init
+        uses: ./.github/actions/terraform_init/
+        with:
+          terraform_deploy_role: ${{ vars.TERRAFORM_DEPLOY_ROLE }}
+
+      - name: Terraform Plan for Cost Analysis
+        id: plan-cost
+        run: |
+          set -o pipefail -ex
+          terraform plan -compact-warnings -no-color -input=false -lock-timeout=5m -out tfplan-cost 2>&1
+          terraform show -json tfplan-cost > tfplan-cost.json
+
+      - uses: overmindtech/cost-signals-action@v1
+        with:
+          overmind-api-key: ${{ secrets.OVM_API_KEY }}
+          infracost-api-key: ${{ secrets.INFRACOST_API_KEY }}
+          terraform-plan-json: ./tfplan-cost.json

--- a/modules/scenarios/manual_sg.tf
+++ b/modules/scenarios/manual_sg.tf
@@ -124,7 +124,7 @@ resource "aws_network_acl_rule" "allow_outbound" {
 
 resource "aws_instance" "webserver" {
   ami           = data.aws_ami.amazon_linux.id
-  instance_type = "t3.micro"
+  instance_type = "t3.small"  # Upgraded from t3.micro for cost analysis demo
   subnet_id     = aws_subnet.restricted-2a.id
   key_name      = "Demo Key Pair"
   
@@ -138,7 +138,7 @@ resource "aws_instance" "webserver" {
 
 resource "aws_instance" "app_server" {
   ami           = data.aws_ami.amazon_linux.id
-  instance_type = "t3.micro"
+  instance_type = "t3.small"  # Upgraded from t3.micro for cost analysis demo
   subnet_id     = aws_subnet.restricted-2b.id
   key_name      = "Demo Key Pair"
   


### PR DESCRIPTION
# Cost Signals Integration Demo

This PR demonstrates the integration of Overmind's Cost Signals Action with our existing policy and blast radius analysis workflows, providing financial visibility for infrastructure changes during the review process.

## What This Changes

## Infrastructure Updates

- Upgraded 2 EC2 instances from t3.micro to t3.small
- Expected cost impact: approximately 100% increase (roughly $17/month additional)
- This change is intentional to demonstrate cost signal detection and severity scaling

### Workflow Integration

- Added a new cost-analysis job that runs in parallel with existing analysis
- Integrates overmindtech/cost-signals-action@v1 for financial impact assessment
- Maintains all existing workflows without disruption (policies, blast radius, change tracking)

## What to Expect
When this PR runs, you should see three types of analysis:

Cost Signals from the cost-signals-action will show the infrastructure cost impact with graduated severity based on percentage change. For this ~100% increase, expect a high severity rating.

Policy Signals from the policy-signals-action will continue to show various policy violations from our test scenarios.

Blast Radius Analysis from the submit-plan action will provide the usual infrastructure dependency analysis.

## Technical Implementation

The cost analysis runs as an independent job with its own terraform plan to avoid conflicts with the main execution flow. It shares the same Overmind integration for unified signal display in PR comments.

### Validation Points

Please verify that:

- All four jobs complete successfully (fmt, policy-checks, execute, cost-analysis)
- Cost signals appear in the PR comment with appropriate severity level
- Policy signals continue to display alongside cost data
- The PR comment provides comprehensive analysis combining cost, policy, and blast radius information
- Prerequisites
- This integration requires both OVM_API_KEY and INFRACOST_API_KEY secrets to be configured in the repository settings.

## Expected Signal Output

Cost signals will appear with quantitative feedback showing the percentage and absolute cost changes. Unlike policy violations which are binary pass/fail, cost signals provide graduated severity scaling based on the magnitude of change.

### Next Steps

After validating this integration works as expected:

- The infrastructure changes in this PR should be reverted in a follow-up
- This cost-analysis job pattern can be applied to other repositories
- Teams can configure cost thresholds based on their approval workflows
- Consider integrating cost gates for high-impact changes
- This is a demonstration PR to validate the cost signals integration. The infrastructure changes are temporary and intended only to trigger cost analysis for testing purposes.
