### PR TITLE
Update python runtime to supported version

### DIFF
--- a/modules/scenarios/message-size-breach/main.tf
+++ b/modules/scenarios/message-size-breach/main.tf
@@ -46,7 +46,7 @@ resource "aws_lambda_function" "image_processor" {
   role            = aws_iam_role.lambda_role.arn
   handler         = "lambda_function.lambda_handler"
   source_code_hash = filebase64sha256("${path.module}/lambda_function.zip")
-  runtime         = "python3.9"
+  runtime          = "python3.13"
   timeout         = var.lambda_timeout
   
   # This will fail when batch size × message size > 256KB (Lambda async limit)


### PR DESCRIPTION
Support for python3.9 runs out on October 30, 2025. This change ensures that we remain in support and this example continues working after February 3, 2026.

See https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy