### PR TITLE
trigger: activate dangerous message size breach scenario

### DIFF
--- a/modules/scenarios/main.tf
+++ b/modules/scenarios/main.tf
@@ -97,7 +97,7 @@ module "message_size_breach" {
   example_env = var.example_env
   
   # The configuration that looks innocent but will break Lambda
-  max_message_size = var.message_size_breach_max_size  # 256KB (safe) vs 1MB (dangerous)
+  max_message_size = var.message_size_breach_max_size  # 25KB (safe) vs 100KB (dangerous)
   batch_size       = var.message_size_breach_batch_size  # 10 messages
   lambda_timeout   = var.message_size_breach_lambda_timeout
   lambda_memory    = var.message_size_breach_lambda_memory

--- a/modules/scenarios/message-size-breach/README.md
+++ b/modules/scenarios/message-size-breach/README.md
@@ -111,7 +111,7 @@ module "message_size_demo" {
   example_env = "demo"
   
   # The "optimization" that kills production
-  max_message_size = 1048576  # 1MB - seems reasonable!
+  max_message_size = 102400   # 100KB - seems reasonable!
   batch_size       = 10       # Same batch size
   lambda_timeout   = 180      # Same timeout
 }

--- a/modules/scenarios/variables.tf
+++ b/modules/scenarios/variables.tf
@@ -50,7 +50,7 @@ variable "enable_message_size_breach_demo" {
 variable "message_size_breach_max_size" {
   description = "Maximum message size for SQS queue in bytes. 25KB (25600) is safe, 100KB (102400) will break Lambda batch processing. Based on AWS Lambda async payload limit of 256KB."
   type        = number
-  default     = 25600  # 25KB - safe default
+  default     = 102400  # 100KB - DANGEROUS! Will exceed Lambda payload limit
   
   validation {
     condition     = var.message_size_breach_max_size >= 1024 && var.message_size_breach_max_size <= 1048576


### PR DESCRIPTION
- Increase message_size_breach_max_size from 25KB to 100KB
- With batch_size=10, total payload becomes 1MB (4x Lambda's 256KB async limit)
- This will cause complete Lambda processing failure during Black Friday
- Demonstrates Overmind's ability to catch non-obvious cross-service limits
- Perfect demo of hidden risk: innocent config change with catastrophic impact