### PR TITLE
refactor: standardise GCE instance network tags (PLAT-2847)

### DIFF
--- a/modules/gcp-service-base/main.tf
+++ b/modules/gcp-service-base/main.tf
@@ -20,7 +20,7 @@ resource "google_compute_instance" "service" {
     subnetwork = var.subnet
   }
 
-  tags = [var.service_name, "allow-ssh"]
+  tags = ["svc-${var.service_name}-prod", "allow-ssh"]
 
   metadata_startup_script = <<-EOF
     #!/bin/bash


### PR DESCRIPTION
## Summary
- Standardise GCE instance network tags to follow the `svc-{name}-prod` convention across all service deployments.

## Context
- PLAT-2847: Enforce consistent resource tagging convention for GCP compute instances.
- This aligns instance tags with the naming standard agreed in the platform architecture review.

## Changes
- Updated the base service module to apply the new tag format to all managed instances.
- Both payments-api and inventory-api instances will receive updated tags on next apply.

## Testing
- Terraform plan reviewed in CI.
- Tag format validated against GCP naming constraints (lowercase, hyphens only).