### PR TITLE
security: narrow internal ingress CIDR (JIRA-4521)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ locals {
     }
   }
 
-  api_internal_cidr = "10.0.0.0/8"
+  api_internal_cidr = "10.0.0.0/16" # SECURITY HARDENING: Narrowed to VPC CIDR per audit findings (JIRA-4521)
   api_domain        = "signals-demo-test.demo"
   api_alert_email   = "alerts@example.com"
 }


### PR DESCRIPTION
## Summary
- Narrow internal ingress CIDR used for service/monitoring access.

## Context
- JIRA-4521: Reduce internal exposure based on audit feedback.

## Testing
- Terraform plan reviewed in CI.

## Rollout / Risk
- If any internal tooling relies on the broader range, it may lose access; monitor health checks and alarms after merge.